### PR TITLE
Add sorting to scans.

### DIFF
--- a/app/assets/stylesheets/base.css
+++ b/app/assets/stylesheets/base.css
@@ -1,0 +1,17 @@
+.sort {
+    position: absolute;
+    top: 1rem;
+    left: 0.5rem;
+    width: 0;
+    height: 0;
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+}
+
+.sort-desc {
+    border-top: 8px solid #fff;
+}
+
+.sort-asc {
+    border-bottom: 8px solid #fff;
+}

--- a/app/controllers/scans_controller.rb
+++ b/app/controllers/scans_controller.rb
@@ -6,6 +6,14 @@ class ScansController < ApplicationController
     @scans = Scan.most_recent.order(overall_score: :desc).sort_by(&:size_grouping)
   end
 
+  def list
+    column = params[:column] == 'name' ? 'sites.name' : params[:column]
+    # this all seems super dangerous; should cleanse column & direction
+    scans = Scan.joins(:site).most_recent.order("size_group asc, #{params[:column]} #{params[:direction]}")
+    render(partial: 'scans', locals: { scans: scans })
+  end
+
+
   # GET /scans/1 or /scans/1.json
   def show
   end

--- a/app/helpers/scans_helper.rb
+++ b/app/helpers/scans_helper.rb
@@ -1,2 +1,19 @@
 module ScansHelper
+  def scan_sort_link(column:, label:)
+    if column == params[:column]
+      link_to(label, list_scans_path(column: column, direction: scan_next_direction))
+    else
+      link_to(label, list_scans_path(column: column, direction: 'desc'))
+    end
+  end
+
+  def scan_next_direction
+    params[:direction] == 'asc' ? 'desc' : 'asc'
+  end
+
+  def sort_indicator
+    tag.span(class: "sort sort-#{params[:direction]}")
+  end
+
+
 end

--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -1,5 +1,6 @@
 class Scan < ApplicationRecord
   belongs_to :site
+  after_save :set_size_group
 
   class << self
     def most_recent_batch
@@ -20,7 +21,7 @@ class Scan < ApplicationRecord
     end
 
     def cleanse_number(scan, value)
-      scan[value].gsub(',','').to_i if scan[value].present?
+      scan[value].present? ? scan[value].gsub(',','').to_i : 0
     end
 
   end
@@ -32,18 +33,32 @@ class Scan < ApplicationRecord
 
   def size_grouping
     if pages > 1000
-      1
+      0
     elsif pages.between?(501,1000)
-      2
+      1
     elsif pages.between?(101,500)
-      3
+      2
     elsif pages.between?(1,100)
-      4
+      3
     elsif pages == 0
-      5
+      4
     else
-      6
+      5
     end
+  end
+
+  def size_group_names
+    %w[large medium small tiny empty error]
+  end
+
+  def size_group_name
+    size_group_names[size_group] if size_group.present?
+  end
+
+  private
+
+  def set_size_group
+    update_column(:size_group, size_grouping)
   end
 
 

--- a/app/views/scans/_scan.html.erb
+++ b/app/views/scans/_scan.html.erb
@@ -3,7 +3,7 @@
     <%= scan.batch_number %>
   </td>
   <td class="py-3 px-6">
-    <%= scan.size_grouping %>
+    <%= scan.size_group_name %>
   </td>
 <!--  <td class="py-3 px-6">-->
     <%#= scan.site.dubbot_id %>

--- a/app/views/scans/_scans.html.erb
+++ b/app/views/scans/_scans.html.erb
@@ -1,18 +1,38 @@
-<div class="overflow-x-auto relative shadow-md sm:rounded-lg mt-10">
+<%= turbo_frame_tag 'scans', class: 'overflow-x-auto relative shadow-md sm:rounded-lg mt-10' do %>
   <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
     <thead class="text-xs text-white uppercase bg-blue-500 dark:bg-gray-700 dark:text-gray-400">
     <tr>
       <th class="py-3 px-6">Batch</th>
       <th class="py-3 px-6">Size Grouping</th>
 <!--      <th class="py-3 px-6">Dubbot Id</th>-->
-      <th class="py-3 px-6">Name</th>
-      <th class="py-3 px-6">Pages</th>
-      <th class="py-3 px-6">Score</th>
-      <th class="py-3 px-6">Broken Links</th>
-      <th class="py-3 px-6">Accessibility Issues</th>
-      <th class="py-3 px-6">Misspellings</th>
+      <th class="text-left py-3 px-6 uppercase font-semibold text-sm hover:cursor-pointer relative">
+        <%= sort_indicator if params[:column] == "site.name" %>
+        <%= scan_sort_link(column: "sites.name", label: "Name") %>
+      </th>
+      <th class="text-left py-3 px-6 uppercase font-semibold text-sm hover:cursor-pointer relative">
+        <%= sort_indicator if params[:column] == "pages" %>
+        <%= scan_sort_link(column: "pages", label: "Pages") %>
+      </th>
+      <th class="text-left py-3 px-6 uppercase font-semibold text-sm hover:cursor-pointer relative">
+        <%= sort_indicator if params[:column] == "overall_score" %>
+        <%= scan_sort_link(column: "overall_score", label: "Score") %>
+      </th>
+      <th class="text-left py-3 px-6 uppercase font-semibold text-sm hover:cursor-pointer relative">
+        <%= sort_indicator if params[:column] == "broken_links" %>
+        <%= scan_sort_link(column: "broken_links", label: "Broken Links") %>
+      </th>
+      <th class="text-left py-3 px-6 uppercase font-semibold text-sm hover:cursor-pointer relative">
+        <%= sort_indicator if params[:column] == "accessibility_issues" %>
+        <%= scan_sort_link(column: "accessibility_issues", label: "Accessibility Issues") %>
+      </th>
+      <th class="text-left py-3 px-6 uppercase font-semibold text-sm hover:cursor-pointer relative">
+        <%= sort_indicator if params[:column] == "misspellings" %>
+        <%= scan_sort_link(column: "misspellings", label: "Misspellings") %>
+      </th>
 <!--      <th class="py-3 px-6">Flagged Words</th>-->
-      <th class="py-3 px-6">Last Crawled On</th>
+      <th class="py-3 px-6">
+        Last Crawled On
+      </th>
       <th class="py-3 px-6"></th>
     </tr>
     </thead>
@@ -22,4 +42,4 @@
     <% end %>
     </tbody>
   </table>
-</div>
+<% end %>

--- a/app/views/sites/_site.html.erb
+++ b/app/views/sites/_site.html.erb
@@ -10,7 +10,7 @@
   <td class="py-3 px-6">
     <%= link_to site.name,site_path(site) %>
   </td>
-  <td> class="py-3 px-6"
+  <td class="py-3 px-6">
     <%= site.url %>
   </td>
   <td class="py-3 px-6">

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,28 +1,31 @@
-<div class="mx-auto md:w-2/3 w-full flex">
+<div class="w-full">
   <div class="mx-auto">
     <% if notice.present? %>
       <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
     <% end %>
 
-    <table class="table-auto">
-      <thead>
-        <tr>
-          <th>test</th>
-          <th>test</th>
-          <th>test</th>
-          <th>test</th>
-          <th>test</th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= render @site %>
-      </tbody>
-    </table>
+    <h1 class="font-bold text-2xl"><%= link_to "Sites", sites_path %></h1>
+    <h2 class="font-bold text-4xl text-blue-500"><%= @site.name %></h2>
+    <dl class="max-w-md text-gray-900 divide-y divide-gray-200 dark:text-white dark:divide-gray-700 mt-5">
+      <div class="flex flex-col pb-3">
+        <dt class="mb-1 text-gray-500 md:text-lg dark:text-gray-400">System</dt>
+        <dd class="text-lg font-semibold"><%= @site.system_name || "No system identified" %></dd>
+      </div>
+      <% if @site.url.present? %>
+        <div class="flex flex-col py-3">
+          <dt class="mb-1 text-gray-500 md:text-lg dark:text-gray-400">URL</dt>
+          <dd class="text-lg font-semibold"><%= @site.url %></dd>
+        </div>
+      <% end %>
+    </dl>
 
-    <%= link_to 'Edit this site', edit_site_path(@site), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to 'Edit', edit_site_path(@site), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
     <div class="inline-block ml-2">
-      <%= button_to 'Destroy this site', site_path(@site), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+      <%= button_to 'Destroy', site_path(@site), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
     </div>
-    <%= link_to 'Back to sites', sites_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+
+    <%= render partial: 'scans/scans', locals: { scans: @site.scans } %>
+
   </div>
+
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
   resources :scans do
     collection do
       post :import_csv
+      get 'list'
     end
+
   end
   root 'public#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20221025011008_add_size_group_to_scan.rb
+++ b/db/migrate/20221025011008_add_size_group_to_scan.rb
@@ -1,0 +1,12 @@
+class AddSizeGroupToScan < ActiveRecord::Migration[7.0]
+  def up
+    add_column :scans, :size_group, :integer
+    Scan.all.each do |scan|
+      scan.save
+    end
+  end
+
+  def down
+    remove_column :scans, :size_group
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_24_171829) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_25_011008) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,6 +26,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_24_171829) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "batch_number"
+    t.integer "size_group"
   end
 
   create_table "sites", force: :cascade do |t|


### PR DESCRIPTION
This adds basic ascending/descending sorting to scans but leaves us with a problem. Right now, I'm showing scans in multiple contexts... on system show, for instance. To make this work we'd have to maintain that state or abandon that UI approach.

The approach might be overcomplicating things from a user perspective, so this might be best just as a filtering option on scans#index.